### PR TITLE
Fix mentions of controllers.py to controllers/root.py

### DIFF
--- a/docs/turbogears/controllers.rst
+++ b/docs/turbogears/controllers.rst
@@ -14,18 +14,18 @@ Basic Dispatch
 -----------------------
 
 When the TurboGears server receives an HTTP request, the requested URL
-is mapped as a call to your controller code located in
-``controllers.py``. Page names map to functions within the controller
-class.
+is mapped as a call to your controller code located in the
+``controllers`` package. Page names map to other controllers or
+methods within the controller class.
 
 For example:
 
-================================== ======================
+================================== ============================
 URL                                Maps to
-================================== ======================
-``http://localhost:8080/index``    ``Root.index()``
-``http://localhost:8080/mypage``   ``Root.mypage()``
-================================== ======================
+================================== ============================
+``http://localhost:8080/index``    ``RootController.index()``
+``http://localhost:8080/mypage``   ``RootController.mypage()``
+================================== ============================
 
 Index and Catch-All pages
 ----------------------------
@@ -34,7 +34,7 @@ Suppose using ``gearbox quickstart`` you generate a TurboGears project
 named "HelloWorld". Your default controller code would be created in
 the file ``HelloWorld/helloworld/controllers/root.py``.
 
-Modify the default ``controllers.py`` to read as follows:
+Modify the default ``root.py`` to read as follows:
 
 .. code-block:: python
 


### PR DESCRIPTION
At least one person stumbled upon that: https://groups.google.com/d/msg/turbogears/djkQGQRglCw/g0mKm57no_wJ
