### PR TITLE
Restore ability to build docs using Sphinx in Python 3.

### DIFF
--- a/docs/code_ext.py
+++ b/docs/code_ext.py
@@ -161,7 +161,7 @@ def code_directive(name, arguments, options, content, lineno,
             source = format_block('\n'.join(data))
         retnode = nodes.literal_block(source, source)
         retnode.line = 1
-    except Exception, e:
+    except Exception as e:
         retnode = state.document.reporter.warning(
             'Reading file %r failed: %r' % (arguments[0], str(e)), line=lineno)
     else:


### PR DESCRIPTION
Apparently "except Exception, e" is no longer acceptable in
Python3. We must use "except Exception as e", which also works
in 2.7.